### PR TITLE
Add wallet provider watch utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm install @yeying-community/web3-bs
 - `onAccountsChanged` / `onChainChanged`
 - `classifyWalletError` / `isUserRejectedWalletAction` / `isWalletReconnectError`
 
+`requestAccounts` 默认会复用同一 provider 上尚未完成的连接请求，避免用户重复点击时触发多个钱包授权弹窗。
+
 ### 2) SIWE + JWT
 
 - `signMessage`

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ npm install @yeying-community/web3-bs
 ### 1) Provider 与账户
 
 - `getProvider` / `requireProvider`
+- `watchProvider`
 - `requestAccounts` / `getAccounts` / `getPreferredAccount` / `watchAccounts`
 - `getChainId` / `getBalance`
 - `onAccountsChanged` / `onChainChanged`
+- `classifyWalletError` / `isUserRejectedWalletAction` / `isWalletReconnectError`
 
 ### 2) SIWE + JWT
 

--- a/docs/SDK能力.md
+++ b/docs/SDK能力.md
@@ -79,7 +79,11 @@
 示例：
 
 ```ts
-import { getProvider, getPreferredAccount } from '@yeying-community/web3-bs';
+import { getProvider, getPreferredAccount, watchProvider } from '@yeying-community/web3-bs';
+
+const stopProviderWatch = watchProvider(({ present }) => {
+  console.log('wallet provider present:', present);
+});
 
 const provider = await getProvider({ timeoutMs: 3000 });
 const { account } = await getPreferredAccount({

--- a/docs/SDK能力.md
+++ b/docs/SDK能力.md
@@ -92,6 +92,8 @@ const { account } = await getPreferredAccount({
 });
 ```
 
+`requestAccounts` 默认会对同一 provider 的并发连接请求做去重。业务按钮仍建议在提交中展示 loading/disabled 状态，但 SDK 会避免重复点击直接触发多个 `eth_requestAccounts`。
+
 ### 3.2 账户变更处理
 
 账户变化后建议清理认证与授权缓存，重新发起登录授权流程：

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yeying-community/web3-bs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "yeying.community@gmail.com",
   "description": "Browser-side DApp access SDK for EIP-1193, SIWE, UCAN, central UCAN and WebDAV",
   "module": "dist/web3-bs.esm.js",

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -18,6 +18,7 @@ const DEFAULT_TIMEOUT = 1000;
 const DEFAULT_ACCOUNT_STORAGE_KEY = 'yeying:last_account';
 const DEFAULT_PROVIDER_POLL_INTERVAL = 100;
 const DEFAULT_PROVIDER_MAX_POLLS = 20;
+const requestAccountsInFlight = new WeakMap<Eip1193Provider, Promise<string[]>>();
 
 function isProvider(value: unknown): value is Eip1193Provider {
   return !!value && typeof (value as Eip1193Provider).request === 'function';
@@ -328,10 +329,24 @@ export async function requestAccounts(
   options: RequestAccountsOptions = {}
 ): Promise<string[]> {
   const provider = options.provider || (await requireProvider());
-  const accounts = (await provider.request({
+  const dedupe = options.dedupe !== false;
+  if (dedupe) {
+    const pending = requestAccountsInFlight.get(provider);
+    if (pending) return pending;
+  }
+
+  const request = provider.request({
     method: 'eth_requestAccounts',
-  })) as string[];
-  return Array.isArray(accounts) ? accounts : [];
+  }).then(accounts => (Array.isArray(accounts) ? accounts : []));
+
+  if (!dedupe) return request;
+
+  requestAccountsInFlight.set(provider, request);
+  try {
+    return await request;
+  } finally {
+    requestAccountsInFlight.delete(provider);
+  }
 }
 
 export async function getAccounts(provider?: Eip1193Provider): Promise<string[]> {

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -8,15 +8,58 @@ import {
   PreferredAccountOptions,
   WatchAccountsOptions,
   AccountsChangedHandler,
+  WatchProviderOptions,
+  ProviderChangedHandler,
+  WalletErrorInfo,
 } from './types';
 
 const YEYING_RDNS = 'io.github.yeying';
 const DEFAULT_TIMEOUT = 1000;
 const DEFAULT_ACCOUNT_STORAGE_KEY = 'yeying:last_account';
+const DEFAULT_PROVIDER_POLL_INTERVAL = 100;
+const DEFAULT_PROVIDER_MAX_POLLS = 20;
+
+function isProvider(value: unknown): value is Eip1193Provider {
+  return !!value && typeof (value as Eip1193Provider).request === 'function';
+}
 
 function getWindowEthereum(): Eip1193Provider | null {
   if (typeof window === 'undefined') return null;
-  return (window as unknown as { ethereum?: Eip1193Provider }).ethereum || null;
+  const ethereum = (window as unknown as { ethereum?: unknown }).ethereum;
+  return isProvider(ethereum) ? ethereum : null;
+}
+
+function getWindowProviderCandidates(): Eip1193Provider[] {
+  if (typeof window === 'undefined') return [];
+
+  const source = window as unknown as Record<string, unknown>;
+  const candidates: Eip1193Provider[] = [];
+  const addProvider = (provider: unknown) => {
+    if (isProvider(provider) && !candidates.includes(provider)) {
+      candidates.push(provider);
+    }
+  };
+
+  for (const name of [
+    'ethereum',
+    'yeeying',
+    'yeying',
+    'coinbaseWallet',
+    'bitkeep',
+    'tokenpocket',
+    '__YEYING_PROVIDER__',
+  ]) {
+    addProvider(source[name]);
+  }
+
+  const ethereum = getWindowEthereum();
+  if (Array.isArray(ethereum?.providers)) {
+    for (const provider of ethereum.providers) {
+      addProvider(provider);
+    }
+  }
+
+  return candidates;
 }
 
 function readStoredAccount(storageKey: string): string | null {
@@ -64,7 +107,7 @@ function selectBestProvider(
   candidates: Eip6963ProviderDetail[],
   preferYeYing: boolean
 ): Eip1193Provider | null {
-  if (candidates.length === 0) return null;
+  if (candidates.length === 0) return selectBestWindowProvider(preferYeYing);
   if (preferYeYing) {
     const yeying = candidates.find(c => isYeYingProvider(c.provider, c.info));
     if (yeying) return yeying.provider;
@@ -72,12 +115,22 @@ function selectBestProvider(
   return candidates[0].provider;
 }
 
+function selectBestWindowProvider(preferYeYing: boolean): Eip1193Provider | null {
+  const candidates = getWindowProviderCandidates();
+  if (candidates.length === 0) return null;
+  if (preferYeYing) {
+    const yeying = candidates.find(provider => isYeYingProvider(provider));
+    if (yeying) return yeying;
+  }
+  return candidates[0];
+}
+
 export async function getProvider(
   options: ProviderDiscoveryOptions = {}
 ): Promise<Eip1193Provider | null> {
   const preferYeYing = options.preferYeYing !== false;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT;
-  const windowProvider = getWindowEthereum();
+  const windowProvider = selectBestWindowProvider(preferYeYing);
 
   if (preferYeYing && isYeYingProvider(windowProvider)) {
     return windowProvider;
@@ -115,7 +168,7 @@ export async function getProvider(
     };
 
     const onEthereumInitialized = () => {
-      const injected = getWindowEthereum();
+      const injected = selectBestWindowProvider(preferYeYing);
       if (preferYeYing && isYeYingProvider(injected)) {
         safeResolve(injected);
       }
@@ -129,7 +182,7 @@ export async function getProvider(
       const best =
         selectBestProvider(discovered, preferYeYing) ||
         windowProvider ||
-        getWindowEthereum();
+        selectBestWindowProvider(preferYeYing);
       safeResolve(best || null);
     }, timeoutMs);
 
@@ -143,6 +196,122 @@ export async function getProvider(
       safeResolve(windowProvider);
     }
   });
+}
+
+export function watchProvider(
+  handler: ProviderChangedHandler,
+  options: WatchProviderOptions = {}
+): () => void {
+  if (typeof window === 'undefined') {
+    handler({ provider: null, present: false });
+    return () => {};
+  }
+
+  const preferYeYing = options.preferYeYing !== false;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_PROVIDER_POLL_INTERVAL;
+  const maxPolls = options.maxPolls ?? DEFAULT_PROVIDER_MAX_POLLS;
+  let stopped = false;
+  let lastProvider: Eip1193Provider | null | undefined;
+  let pollCount = 0;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const emit = () => {
+    if (stopped) return;
+    const provider = selectBestWindowProvider(preferYeYing);
+    if (provider === lastProvider) return;
+    lastProvider = provider;
+    handler({ provider, present: !!provider });
+  };
+
+  const poll = () => {
+    if (stopped) return;
+    emit();
+    pollCount += 1;
+    if (lastProvider || pollCount >= maxPolls) return;
+    pollTimer = setTimeout(poll, pollIntervalMs);
+  };
+
+  const handleProviderReady = () => {
+    emit();
+  };
+
+  window.addEventListener('ethereum#initialized', handleProviderReady);
+  window.addEventListener('eip6963:announceProvider', handleProviderReady as EventListener);
+
+  try {
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+  } catch {
+    // Ignore unsupported event dispatch environments.
+  }
+
+  poll();
+
+  return () => {
+    stopped = true;
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+    }
+    window.removeEventListener('ethereum#initialized', handleProviderReady);
+    window.removeEventListener('eip6963:announceProvider', handleProviderReady as EventListener);
+  };
+}
+
+export function getWalletErrorMessage(error: unknown): string {
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message || String(error);
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string') return message;
+  return String(error);
+}
+
+export function getWalletErrorCode(error: unknown): number | null {
+  const code = Number((error as { code?: unknown })?.code);
+  if (!Number.isNaN(code)) return code;
+  const causeCode = Number((error as { cause?: { code?: unknown } })?.cause?.code);
+  if (!Number.isNaN(causeCode)) return causeCode;
+  return null;
+}
+
+export function classifyWalletError(error: unknown): WalletErrorInfo {
+  const code = getWalletErrorCode(error);
+  const message = getWalletErrorMessage(error);
+  const lowerMessage = message.toLowerCase();
+
+  if (code === 4001 || lowerMessage.includes('user rejected')) {
+    return { type: 'userRejected', code, message };
+  }
+
+  if (
+    code === 4900 ||
+    lowerMessage.includes('disconnected') ||
+    lowerMessage.includes('reconnect') ||
+    lowerMessage.includes('not connected')
+  ) {
+    return { type: 'disconnected', code, message };
+  }
+
+  if (lowerMessage.includes('timeout')) {
+    return { type: 'timeout', code, message };
+  }
+
+  if (
+    lowerMessage.includes('no injected wallet provider') ||
+    lowerMessage.includes('未检测到钱包')
+  ) {
+    return { type: 'notFound', code, message };
+  }
+
+  return { type: 'unknown', code, message };
+}
+
+export function isUserRejectedWalletAction(error: unknown): boolean {
+  return classifyWalletError(error).type === 'userRejected';
+}
+
+export function isWalletReconnectError(error: unknown): boolean {
+  const type = classifyWalletError(error).type;
+  return type === 'disconnected' || type === 'timeout';
 }
 
 export async function requireProvider(

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -63,6 +63,7 @@ export type WalletErrorInfo = {
 
 export interface RequestAccountsOptions {
   provider?: Eip1193Provider;
+  dedupe?: boolean;
 }
 
 export type AccountSelection = {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -17,6 +17,8 @@ export interface Eip1193Provider {
   };
   isMetaMask?: boolean;
   isYeYing?: boolean;
+  providers?: Eip1193Provider[];
+  [key: string]: unknown;
 }
 
 export interface ProviderInfo {
@@ -35,6 +37,29 @@ export interface ProviderDiscoveryOptions {
   timeoutMs?: number;
   preferYeYing?: boolean;
 }
+
+export interface WatchProviderOptions extends ProviderDiscoveryOptions {
+  pollIntervalMs?: number;
+  maxPolls?: number;
+}
+
+export type ProviderChangedHandler = (payload: {
+  provider: Eip1193Provider | null;
+  present: boolean;
+}) => void;
+
+export type WalletErrorType =
+  | 'userRejected'
+  | 'disconnected'
+  | 'timeout'
+  | 'notFound'
+  | 'unknown';
+
+export type WalletErrorInfo = {
+  type: WalletErrorType;
+  code: number | null;
+  message: string;
+};
 
 export interface RequestAccountsOptions {
   provider?: Eip1193Provider;


### PR DESCRIPTION
## Summary
- add watchProvider for injected wallet detection across delayed injection, EIP-6963 announcements, and ethereum#initialized
- enhance getProvider to inspect common injected provider aliases and window.ethereum.providers
- add wallet error classification helpers
- dedupe concurrent requestAccounts calls on the same provider to avoid repeated wallet authorization popups
- bump package version to 1.0.9

## Verification
- npm run test