### PR TITLE
Verify npm identity before publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,7 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm install
       - run: npm ci
       - run: npm test
 
@@ -24,12 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-      - run: npm install
+      - run: npm ci
       - run: npm run build
+      - name: Verify npm publish identity
+        run: |
+          npm whoami --registry=https://registry.npmjs.org/
+          npm owner ls @yeying-community/web3-bs --registry=https://registry.npmjs.org/
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Summary
- use npm ci consistently in the publish workflow
- upgrade setup-node to v4
- print npm whoami and package owners before npm publish so publish-token problems are visible in logs

## Context
The 1.0.9 publish failed with npm E404 even though @yeying-community/web3-bs exists and 1.0.8 was published. npm owner ls shows the package owner is kobofare, so this check helps confirm whether the GitHub secret resolves to a token with publish access.

## Verification
- npm run test