### PR TITLE
Use npm install in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm ci
+      - run: npm install
       - run: npm test
 
   publish-npm:
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - name: Verify npm publish identity
         run: |


### PR DESCRIPTION
## Summary
- switch the publish workflow install steps back to npm install because this repository does not track package-lock.json

## Verification
- npm run test